### PR TITLE
Fix hitreg timing, hit detection, and sound/particle handling

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,8 +6,8 @@ mod_version=1.0.6+1.21.11
 maven_group=you.jass
 archives_base_name=BetterHitreg
 minecraft_version=1.21.11
-yarn_mappings=1.21.11+build.5
+yarn_mappings=1.21.11+build.6
 
 # Fabric Properties
-loader_version=0.19.2
+loader_version=0.19.3
 fabric_version=0.141.4+1.21.11

--- a/src/main/java/you/jass/betterhitreg/hitreg/Hit.java
+++ b/src/main/java/you/jass/betterhitreg/hitreg/Hit.java
@@ -29,6 +29,7 @@ public class Hit {
     public boolean hadShield;
     public boolean wasBlocked;
     public boolean wasSprinting;
+    public boolean wasMovingFast;
     public boolean wasFalling;
     public boolean wasOnGround;
     public boolean wasClimbing;
@@ -76,7 +77,7 @@ public class Hit {
     public void load() {
         shouldKnockback = !tooEarlyForSpecial && wasSprinting && sprintWasReset;
         shouldCrit = !tooEarlyForSpecial && !shouldKnockback && wasFalling && !wasOnGround && !wasClimbing && !wasTouchingWater && !wasInVehicle && !wasBlind;
-        shouldSweep = !tooEarlyForSpecial && wasHoldingSword && wasOnGround && (!wasSprinting);
+        shouldSweep = !tooEarlyForSpecial && !shouldKnockback && wasHoldingSword && wasOnGround && !wasMovingFast;
         shouldPick = !shouldKnockback && !shouldCrit && !shouldSweep;
         shouldFullPick = !tooEarlyForSpecial && shouldPick;
         shouldHalfPick = !shouldFullPick && shouldPick;
@@ -87,6 +88,7 @@ public class Hit {
 
         //decide once at hit time whether the mod replaces the server's feedback, the target's blocking state may change before the server's packets arrive
         boolean handled = Hitreg.isToggled();
+        Hitreg.lastSwingHandled = handled;
 
         if (!tooEarlyForDamage) {
             HitTracker.add(this);

--- a/src/main/java/you/jass/betterhitreg/hitreg/Hit.java
+++ b/src/main/java/you/jass/betterhitreg/hitreg/Hit.java
@@ -85,8 +85,15 @@ public class Hit {
         if (type == null) return;
         expectedSound = type.getMainSound();
 
-        if (!tooEarlyForDamage) HitTracker.add(this);
-        if (Hitreg.isToggled()) Scheduler.schedule(Settings.getHitreg(), this::run);
+        //decide once at hit time whether the mod replaces the server's feedback, the target's blocking state may change before the server's packets arrive
+        boolean handled = Hitreg.isToggled();
+
+        if (!tooEarlyForDamage) {
+            HitTracker.add(this);
+            Hitreg.lastHitHandled = handled;
+        }
+
+        if (handled) Scheduler.schedule(Settings.getHitreg(), this::run);
     }
 
     public void run() {

--- a/src/main/java/you/jass/betterhitreg/hitreg/Hitreg.java
+++ b/src/main/java/you/jass/betterhitreg/hitreg/Hitreg.java
@@ -35,8 +35,9 @@ public class Hitreg {
     public static long lastAnimation;
     public static boolean alreadyAnimated;
     public static boolean alreadyKnockedBack;
-    public static boolean wasMovingForward;
+    public static boolean wasSprinting;
     public static boolean sprintIsReset = true;
+    public static boolean lastHitHandled;
     public static boolean fighting = false;
     public static boolean wasGhosted;
     public static boolean newTarget = true;
@@ -101,9 +102,10 @@ public class Hitreg {
         updateFightState();
         updateGround();
 
-        boolean movingForward = client.options.forwardKey.isPressed();
-        if (movingForward && !wasMovingForward) sprintIsReset = true;
-        wasMovingForward = movingForward;
+        //the server only re-learns your sprint when the client restarts sprinting across ticks (W-tap, shift release, etc.)
+        boolean sprinting = client.player.isSprinting();
+        if (sprinting && !wasSprinting) sprintIsReset = true;
+        wasSprinting = sprinting;
 
         boolean swinging = client.options.attackKey.isPressed();
         if (swinging && !wasSwinging) yourSwings++;

--- a/src/main/java/you/jass/betterhitreg/hitreg/Hitreg.java
+++ b/src/main/java/you/jass/betterhitreg/hitreg/Hitreg.java
@@ -38,6 +38,7 @@ public class Hitreg {
     public static boolean wasSprinting;
     public static boolean sprintIsReset = true;
     public static boolean lastHitHandled;
+    public static boolean lastSwingHandled;
     public static boolean fighting = false;
     public static boolean wasGhosted;
     public static boolean newTarget = true;
@@ -259,7 +260,8 @@ public class Hitreg {
     public static void updateFightState() {
         bothAlive = client.player != null && target != null && client.player.isAlive() && target.isAlive() && !client.player.isSpectator() && !target.isSpectator();
         targetHasShield = target != null && Hitreg.target.isHolding(Items.SHIELD);
-        targetIsBlocking = targetHasShield && Hitreg.target.isUsingItem();
+        //isUsingItem is also true while eating/drinking, isBlocking checks the shield is actually raised
+        targetIsBlocking = targetHasShield && Hitreg.target.isBlocking();
 
         if (bothAlive) {
             distance = distanceToTarget();

--- a/src/main/java/you/jass/betterhitreg/mixin/AttackMixin.java
+++ b/src/main/java/you/jass/betterhitreg/mixin/AttackMixin.java
@@ -7,6 +7,8 @@ import net.minecraft.entity.decoration.ArmorStandEntity;
 import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Items;
+import net.minecraft.registry.tag.ItemTags;
+import net.minecraft.util.math.MathHelper;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -35,16 +37,18 @@ public abstract class AttackMixin {
         hit.cooldown = client.player.getAttackCooldownProgress(0.5f);
         hit.tooEarlyForDamage = hitEarly;
         hit.tooEarlyForSpecial = hit.cooldown <= 0.9f;
-        hit.hadShield = targetHasShield;
-        hit.wasBlocked = targetIsBlocking;
+        hit.hadShield = Hitreg.target.isHolding(Items.SHIELD);
+        hit.wasBlocked = Hitreg.target.isBlocking();
         hit.wasSprinting = client.player.isSprinting();
-        hit.wasFalling = client.player.getVelocity().getY() < -0.08;
+        hit.wasFalling = client.player.fallDistance > 0;
         hit.wasOnGround = client.player.isOnGround();
         hit.wasClimbing = client.player.isClimbing();
         hit.wasTouchingWater = client.player.isTouchingWater();
         hit.wasInVehicle = client.player.hasVehicle();
         hit.wasBlind = client.player.hasStatusEffect(StatusEffects.BLINDNESS);
-        hit.wasHoldingSword = client.player.getMainHandStack().getItem().getName().getString().toLowerCase().contains("sword");
+        hit.wasHoldingSword = client.player.getMainHandStack().isIn(ItemTags.SWORDS);
+        //vanilla only sweeps below 2.5x movement speed
+        hit.wasMovingFast = client.player.getMovement().horizontalLengthSquared() >= MathHelper.square(client.player.getMovementSpeed() * 2.5);
         hit.swordHadSharpness = MultiVersion.hasSharpness();
         hit.sprintWasReset = sprintIsReset;
         hit.wasNewTarget = lastTarget != target.getId();
@@ -57,8 +61,6 @@ public abstract class AttackMixin {
             fighting = true;
             hitByAnother = hit.wasHitByAnother;
             newTarget = hit.wasNewTarget;
-            targetHasShield = Hitreg.target.isHolding(Items.SHIELD);
-            targetIsBlocking = targetHasShield && Hitreg.target.isUsingItem();
             lastAttackLocation = MultiVersion.getBasePosition(client.player);
             lastAttack = System.currentTimeMillis();
             lastTarget = target.getId();

--- a/src/main/java/you/jass/betterhitreg/mixin/AttackMixin.java
+++ b/src/main/java/you/jass/betterhitreg/mixin/AttackMixin.java
@@ -8,7 +8,6 @@ import net.minecraft.entity.effect.StatusEffects;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Items;
 import net.minecraft.registry.tag.ItemTags;
-import net.minecraft.util.math.MathHelper;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -47,8 +46,7 @@ public abstract class AttackMixin {
         hit.wasInVehicle = client.player.hasVehicle();
         hit.wasBlind = client.player.hasStatusEffect(StatusEffects.BLINDNESS);
         hit.wasHoldingSword = client.player.getMainHandStack().isIn(ItemTags.SWORDS);
-        //vanilla only sweeps below 2.5x movement speed
-        hit.wasMovingFast = client.player.getMovement().horizontalLengthSquared() >= MathHelper.square(client.player.getMovementSpeed() * 2.5);
+        hit.wasMovingFast = MultiVersion.isMovingFast();
         hit.swordHadSharpness = MultiVersion.hasSharpness();
         hit.sprintWasReset = sprintIsReset;
         hit.wasNewTarget = lastTarget != target.getId();

--- a/src/main/java/you/jass/betterhitreg/mixin/DamageMixin.java
+++ b/src/main/java/you/jass/betterhitreg/mixin/DamageMixin.java
@@ -35,7 +35,10 @@ public abstract class DamageMixin {
 
     @ModifyVariable(method = "onDamaged(Lnet/minecraft/entity/damage/DamageSource;)V", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/entity/LivingEntity;getHurtSound(Lnet/minecraft/entity/damage/DamageSource;)Lnet/minecraft/sound/SoundEvent;"), ordinal = 0)
     private SoundEvent onDamaged(SoundEvent original, DamageSource damageSource) {
-        return Toggle.SILENCE_THEM.toggled() ? null : original;
+        //only silence your own hurt sound, other entities aren't "their hits"
+        LivingEntity entity = (LivingEntity) (Object) this;
+        boolean isYou = Hitreg.client.player != null && Hitreg.client.player.getId() == entity.getId();
+        return Toggle.SILENCE_THEM.toggled() && isYou ? null : original;
     }
 
     @Inject(method = "onDamaged", at = @At("HEAD"), cancellable = true)

--- a/src/main/java/you/jass/betterhitreg/mixin/NetworkMixin.java
+++ b/src/main/java/you/jass/betterhitreg/mixin/NetworkMixin.java
@@ -15,7 +15,7 @@ public abstract class NetworkMixin {
     @ModifyArg(method = "onEntityDamage(Lnet/minecraft/network/packet/s2c/play/EntityDamageS2CPacket;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;onDamaged(Lnet/minecraft/entity/damage/DamageSource;)V"))
     private DamageSource onEntityDamage(DamageSource damageSource) {
         if (Toggle.HIDE_ANIMATIONS.toggled()) return new DontAnimate(damageSource);
-        else if (damageSource != null && damageSource.getAttacker() != null && client.player != null && client.player.getId() == damageSource.getAttacker().getId() && isToggled() && withinFight && System.currentTimeMillis() - lastAttack <= 1000) return new DontAnimate(damageSource);
+        else if (damageSource != null && damageSource.getAttacker() != null && client.player != null && client.player.getId() == damageSource.getAttacker().getId() && lastHitHandled && withinFight && System.currentTimeMillis() - lastAttack <= 1000) return new DontAnimate(damageSource);
         return damageSource;
     }
 }

--- a/src/main/java/you/jass/betterhitreg/utility/MultiVersion.java
+++ b/src/main/java/you/jass/betterhitreg/utility/MultiVersion.java
@@ -41,6 +41,7 @@ import net.minecraft.network.packet.s2c.play.EntityAnimationS2CPacket;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.text.*;
+import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.Vec3d;
 
 import org.joml.Matrix4f;
@@ -134,6 +135,16 @@ public class MultiVersion {
 
         //version 1.21.9+
         return entity.getEntityPos();
+    }
+
+    public static boolean isMovingFast() {
+        //vanilla doesn't sweep when moving faster than your movement speed, 1.21.2 changed the check to compare actual movement against 2.5x
+
+        //version 1.21.1-
+        //return client.player.horizontalSpeed - client.player.prevHorizontalSpeed >= client.player.getMovementSpeed();
+
+        //version 1.21.2+
+        return client.player.getMovement().horizontalLengthSquared() >= MathHelper.square(client.player.getMovementSpeed() * 2.5);
     }
 
     public static void playParticles(String type, Entity entity) {

--- a/src/main/java/you/jass/betterhitreg/utility/PacketProcessor.java
+++ b/src/main/java/you/jass/betterhitreg/utility/PacketProcessor.java
@@ -11,7 +11,6 @@ import java.util.*;
 
 import static you.jass.betterhitreg.hitreg.Hitreg.alreadyAnimated;
 import static you.jass.betterhitreg.hitreg.Hitreg.client;
-import static you.jass.betterhitreg.hitreg.Hitreg.isToggled;
 import static you.jass.betterhitreg.hitreg.Hitreg.last100Regs;
 import static you.jass.betterhitreg.hitreg.Hitreg.lastAnimation;
 import static you.jass.betterhitreg.hitreg.Hitreg.lastAttack;
@@ -50,12 +49,13 @@ public class PacketProcessor {
                 processDelayedSounds(true);
             }
 
-            else if (client.player.getId() == packet.entityId()) {
+            else if (client.player != null && client.player.getId() == packet.entityId()) {
                 //if processing never ran on the network thread, we need to update the timestamp here
                 if (System.currentTimeMillis() - tookDamageTimestamp > 50) tookDamageTimestamp = System.currentTimeMillis() - 2;
 
                 lastAttacked = tookDamageTimestamp;
-                Hitreg.theirHits++;
+                //fall/environment damage shouldn't count as their hit
+                if (packet.sourceCauseId() == lastTarget) Hitreg.theirHits++;
                 processDelayedSounds(false);
             }
         }
@@ -89,7 +89,7 @@ public class PacketProcessor {
 
         if (sound.modern || sound.legacy) {
             boolean result = processSound(sound);
-            if (!Hitreg.lastHitHandled && !Toggle.SILENCE_SELF.toggled() && !Toggle.SILENCE_THEM.toggled() && !Toggle.SILENCE_OTHER_FIGHTS.toggled()) {
+            if (!Hitreg.lastHitHandled && !Hitreg.lastSwingHandled && !Toggle.SILENCE_SELF.toggled() && !Toggle.SILENCE_THEM.toggled() && !Toggle.SILENCE_OTHER_FIGHTS.toggled()) {
                 sound.skip = true;
                 return true;
             }
@@ -121,7 +121,8 @@ public class PacketProcessor {
         if (!soundWithinFight) return !Toggle.SILENCE_OTHER_FIGHTS.toggled();
 
         //block nodamage sounds because they don't actually register hits so we don't know who they're from
-        if (isToggled() && sound.sound.contains("nodamage")) return false;
+        //nodamage answers a swing rather than a registered hit, so use the swing-time decision
+        if (Hitreg.lastSwingHandled && sound.sound.contains("nodamage")) return false;
 
         //if the sound wasn't from either of you
         boolean fromYou = sound.wasFromYou();

--- a/src/main/java/you/jass/betterhitreg/utility/PacketProcessor.java
+++ b/src/main/java/you/jass/betterhitreg/utility/PacketProcessor.java
@@ -38,7 +38,6 @@ public class PacketProcessor {
                 //if processing never ran on the network thread, we need to update the timestamp here
                 if (System.currentTimeMillis() - dealtDamageTimestamp > 50) dealtDamageTimestamp = System.currentTimeMillis() - 2;
 
-                boolean isToggled = isToggled();
                 boolean withinFight = Hitreg.withinFight;
                 boolean hasBeenAnimated = alreadyAnimated;
                 HitTracker.add(new Animation(dealtDamageTimestamp));
@@ -47,7 +46,7 @@ public class PacketProcessor {
                 long delay = dealtDamageTimestamp - lastAttack;
                 if (Toggle.ALERT_DELAYS.toggled() && !hasBeenAnimated && delay <= 500) message("hitreg §7was §f" + delay + "§7ms", "/hitreg alertDelays");
                 if (delay <= 500) last100Regs.addDelay((int) delay);
-                if (!isToggled && withinFight && Toggle.PARTICLES_EVERY_HIT.toggled()) playParticles("ENCHANTED_HIT", target);
+                if (!Hitreg.lastHitHandled && withinFight && Toggle.PARTICLES_EVERY_HIT.toggled()) playParticles("ENCHANTED_HIT", target);
                 processDelayedSounds(true);
             }
 
@@ -66,7 +65,6 @@ public class PacketProcessor {
 
     public static boolean processAnimation(EntityAnimationS2CPacket packet) {
         if (lastTarget != getAnimationId(packet)) return true;
-        boolean isToggled = isToggled();
         boolean withinFight = Hitreg.withinFight;
 
         //swing hand
@@ -74,12 +72,12 @@ public class PacketProcessor {
 
         //crit particle
         if (packet.getAnimationId() == 4) {
-            if (isToggled && withinFight) return false;
+            if (Hitreg.lastHitHandled && withinFight) return false;
         }
 
         //enchanted particle
         else if (packet.getAnimationId() == 5) {
-            if ((Toggle.PARTICLES_EVERY_HIT.toggled() || isToggled) && withinFight) return false;
+            if ((Toggle.PARTICLES_EVERY_HIT.toggled() || Hitreg.lastHitHandled) && withinFight) return false;
         }
 
         return true;
@@ -91,7 +89,7 @@ public class PacketProcessor {
 
         if (sound.modern || sound.legacy) {
             boolean result = processSound(sound);
-            if (!isToggled() && !Toggle.SILENCE_SELF.toggled() && !Toggle.SILENCE_THEM.toggled() && !Toggle.SILENCE_OTHER_FIGHTS.toggled()) {
+            if (!Hitreg.lastHitHandled && !Toggle.SILENCE_SELF.toggled() && !Toggle.SILENCE_THEM.toggled() && !Toggle.SILENCE_OTHER_FIGHTS.toggled()) {
                 sound.skip = true;
                 return true;
             }
@@ -110,21 +108,20 @@ public class PacketProcessor {
             if (sound.skip) continue;
             boolean shouldPlay;
             if (!sound.wasRecent()) shouldPlay = !Toggle.SILENCE_OTHER_FIGHTS.toggled();
-            else if (fromYou) shouldPlay = !Toggle.SILENCE_SELF.toggled() && !isToggled();
+            else if (fromYou) shouldPlay = !Toggle.SILENCE_SELF.toggled() && !Hitreg.lastHitHandled;
             else shouldPlay = !Toggle.SILENCE_THEM.toggled();
             if (shouldPlay) sound.play();
         }
     }
 
     private static boolean processSound(Sound sound) {
-        boolean isToggled = isToggled();
         boolean soundWithinFight = sound.withinFight();
 
         //if the sound happened far away, then block it if were silencing other fights and skip it if were not
         if (!soundWithinFight) return !Toggle.SILENCE_OTHER_FIGHTS.toggled();
 
         //block nodamage sounds because they don't actually register hits so we don't know who they're from
-        if (isToggled && sound.sound.contains("nodamage")) return false;
+        if (isToggled() && sound.sound.contains("nodamage")) return false;
 
         //if the sound wasn't from either of you
         boolean fromYou = sound.wasFromYou();
@@ -144,7 +141,7 @@ public class PacketProcessor {
         }
 
         //block the sound based on whether you hit them or they hit you
-        if (fromYou && (isToggled || Toggle.SILENCE_SELF.toggled())) return false;
+        if (fromYou && (Hitreg.lastHitHandled || Toggle.SILENCE_SELF.toggled())) return false;
         if (fromThem && Toggle.SILENCE_THEM.toggled()) return false;
 
         //block all modern attack sounds if legacy sounds are enabled


### PR DESCRIPTION
Fixes several cases where client-side hit feedback could disagree with the server because toggle state or entity state was checked too late (when packets arrived instead of at swing time).

Changes
- Snapshot hitreg toggle at swing time (`lastHitHandled` / `lastSwingHandled`) so sounds, particles, and animations stay consistent
- Improve hit type detection: sprint reset, shield blocking (`isBlocking`), crit/sweep checks, sword tag detection
- Fix sound handling: only silence your own hurt sound with `SILENCE_THEM`, ignore fall damage in hit counters, handle `nodamage` sounds at swing time
- Move sweep speed check to `MultiVersion.isMovingFast()` for version-aware behavior
- Bump Fabric loader and yarn mappings for 1.21.11